### PR TITLE
Make it parse some other legal time formats. In particular: 2018-04-04T12:34:56+0400

### DIFF
--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -251,7 +251,8 @@ def str_to_time(timestr, format=TIME_FORMAT):
             else:
                 elem = TIME_FORMAT_WITH_FRAGMENT_ZONE.match(timestr)
                 timedata = elem.group(1) + 'Z'
-                offset = timedelta(hours=int(elem.group(4)), minutes=int(elem.group(5)))
+                offset = timedelta(hours=int(elem.group(4)),
+                                   minutes=int(elem.group(5)))
                 if elem.group(3) == '+':
                     offset = -offset
         except Exception as exc:

--- a/tests/test_10_time_util.py
+++ b/tests/test_10_time_util.py
@@ -124,6 +124,9 @@ def test_str_to_time():
     # some IdPs omit the trailing Z, and SAML spec is unclear if it is actually required
     t = calendar.timegm(str_to_time("2000-01-12T00:00:00"))
     assert t == 947635200
+    # some IdPs use the explicit timezone format
+    t = calendar.timegm(str_to_time("2000-01-12T00:00:00+02:00"))
+    assert t == 947635200 - 2 * 3600
 
 def test_instant():
     inst = str_to_time(instant())


### PR DESCRIPTION
Just add support for parsing the time format that has an explicit timezone. This is made more complex by the fact that the python 2.7 documentation is wrong and it does not support %z in strptime.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



